### PR TITLE
Allow other astrometry index locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Otherwise, when the API service is started, all index files will be downloaded, 
 
 Note: These files are required and may take time to download (~GB total).
 
-### 3. Create astrometry configuration file
+### 4. Create astrometry configuration file
 
 ```bash
 mkdir -p `dirname $ASTROMETRY_CONFIG`

--- a/README.md
+++ b/README.md
@@ -71,32 +71,45 @@ Running locally will install the currently checked out version of the CAT.
 The astrometric calibration pipeline depends on **astrometry.net** index files and a corresponding configuration file. These are required for WCS solving.
 
 ### 1. Install system dependencies
+
 ```
 sudo apt install astrometry.net netpbm
 ```
 
-### 2. Download astrometry index files
+### 2. Set required environment variables
+
+Define the location of the astrometry.net configuration file and index files.
+For example:
+
+```bash
+export ASTROMETRY_CONFIG=$HOME/.astrometry/config
+export ASTROMETRY_INDEX_DIR=$HOME/.astrometry/data
 ```
-mkdir -p ~/.astrometry/data
+
+### 3. Download astrometry index files
+
+Optionally download a subset for testing:
+
+```bash
+mkdir -p $ASTROMETRY_INDEX_DIR
 
 for i in 00 01 02 03 04 05 06 07; do
-  wget -P ~/.astrometry/data \
+  wget -P $ASTROMETRY_INDEX_DIR \
     https://portal.nersc.gov/project/cosmo/temp/dstn/index-5200/index-5204-$i.fits
 done
-
 ```
+
+Otherwise, when the API service is started, all index files will be downloaded, as needed.
+
 Note: These files are required and may take time to download (~GB total).
 
 ### 3. Create astrometry configuration file
-```
-mkdir -p ~/.astrometry
-: > ~/.astrometry/config
 
-for f in ~/.astrometry/data/index-*.fits; do
-  echo "index $f" >> ~/.astrometry/config
-done
-```
-### 4. Set required environment variable
-```
-export ASTROMETRY_CONFIG=$HOME/.astrometry/config
+```bash
+mkdir -p `dirname $ASTROMETRY_CONFIG`
+cat > $ASTROMETRY_CONFIG <<EOF
+cpulimit 300
+add_path $ASTROMETRY_INDEX_DIR
+autoindex
+EOF
 ```

--- a/catch_analysis_tools/app/astrometry_readiness/state.py
+++ b/catch_analysis_tools/app/astrometry_readiness/state.py
@@ -1,6 +1,7 @@
 import threading
 
-from .constants import DEFAULT_INDEX_DIR, INDEX_URL
+from .constants import INDEX_URL
+from .get_index_dir import get_index_dir
 
 state_lock = threading.RLock()
 worker = None
@@ -10,7 +11,7 @@ status = {
     "message": "Astrometry data has not been checked yet.",
     "files_present": 0,
     "expected_files": None,
-    "index_dir": DEFAULT_INDEX_DIR,
+    "index_dir": get_index_dir().absolute,
     "index_url": INDEX_URL,
     "updated_at": None,
     "error": None,

--- a/catch_analysis_tools/astrometry.py
+++ b/catch_analysis_tools/astrometry.py
@@ -175,7 +175,9 @@ def retrieve_sources(source_list, wcs_solution):
 
     """
 
-    world = wcs_solution.pixel_to_world(source_list["x"], source_list["y"])
+    world = wcs_solution.pixel_to_world(
+        np.array(source_list["x"]), np.array(source_list["y"])
+    )
     source_list["RA"] = [c.ra.deg for c in world]
     source_list["Dec"] = [c.dec.deg for c in world]
     sky_coords = SkyCoord(source_list["RA"], source_list["Dec"], unit="deg")


### PR DESCRIPTION
A hard coded default was being used for the astometry.net config file, rather than the environment variable.
